### PR TITLE
Copy ASP.NET Core refs before coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ This action requires that the .Net SDK is installed as needed to build and execu
 
 Specify a test project name. If provided, only tests within this project will be executed. If left empty, all tests will be executed.
 
+## `copy-aspnetcore-refs`
+
+*Optional*
+
+Defaults to `true`.
+
+Copies `Microsoft.AspNetCore*.dll` files from any `refs` directories under the configured test project's `bin` output into the corresponding output directory before coverage runs. This helps Coverlet instrument ASP.NET Core shared-framework libraries whose reference assemblies are otherwise only present under `refs/`.
+
 ## `sonar-login`
 
 *Required*

--- a/action.yaml
+++ b/action.yaml
@@ -24,6 +24,9 @@ inputs:
   dotnet-test-project:
     description: "Project name for test coverage. If not provided, all tests will run."
     default: ""
+  copy-aspnetcore-refs:
+    description: "Copy ASP.NET Core reference assemblies from test output refs folders before coverage runs."
+    default: "true"
   copy-dlls:
     description: "Copy DLLs to a directory. If not provided, the Copy DLLs step will be skipped."
     default: "false"
@@ -113,6 +116,33 @@ runs:
       name: Copy Required DLLs
       if: ${{ inputs.copy-dlls == 'true' }}
       run: cp -f ${{ inputs.files-to-copy }} ${{ inputs.copy-to-directory }}
+      shell: bash
+
+    - id: copy-aspnetcore-reference-dlls
+      name: Copy ASP.NET Core Reference DLLs
+      if: ${{ inputs.copy-aspnetcore-refs == 'true' && inputs.dotnet-test-project != '' }}
+      run: |
+        set -euo pipefail
+
+        copied=0
+        while IFS= read -r refs_dir; do
+          target_dir="$(dirname "$refs_dir")"
+          shopt -s nullglob
+          aspnetcore_dlls=("$refs_dir"/Microsoft.AspNetCore*.dll)
+          shopt -u nullglob
+
+          if [[ ${#aspnetcore_dlls[@]} -eq 0 ]]; then
+            continue
+          fi
+
+          cp -f "${aspnetcore_dlls[@]}" "$target_dir"
+          copied=$((copied + ${#aspnetcore_dlls[@]}))
+          echo "Copied ${#aspnetcore_dlls[@]} ASP.NET Core reference DLLs from $refs_dir to $target_dir"
+        done < <(find "${{ inputs.dotnet-test-project }}/bin" -type d -name refs 2>/dev/null)
+
+        if [[ $copied -eq 0 ]]; then
+          echo "No ASP.NET Core reference DLLs were copied."
+        fi
       shell: bash
 
     - id: test


### PR DESCRIPTION
## Summary
- add an action input to copy ASP.NET Core reference assemblies before coverage runs
- copy `Microsoft.AspNetCore*.dll` from test output `refs` folders into the parent output directory
- document the behavior in the action README

## Why
Coverlet can fail to instrument ASP.NET Core shared-framework libraries when the reference assemblies are only present under the test output `refs` directory. In `Platform`, this showed up as `Platform.Common.dll` failing instrumentation with an `AssemblyResolutionException` for `Microsoft.AspNetCore.Mvc.Core`, which caused Sonar to import a coverage file with zero credit for that project.

This change centralizes the existing workaround pattern in the shared action so consuming repos do not need one-off workflow patches.

## Validation
- validated the copy behavior locally in `Platform`
- after copying the ASP.NET Core reference assemblies into the test output directory, `dotnet test ... /p:CollectCoverage=true /p:CoverletOutputFormat=opencover` reported `Platform.Common` coverage instead of dropping it
