### PR TITLE
Replace sonar-login with sonar-token in action.yaml

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -2,7 +2,7 @@ name: SonarCloud Scanner (dotnet)
 author: RightNow Ministries
 description: Runs SonarCloud Static Analysis and Code Coverage for .Net Core Projects
 inputs:
-  sonar-login:
+  sonar-token:
     description: "Sonar Auth Token"
     required: true
   sonar-project-key:
@@ -75,7 +75,7 @@ runs:
         dotnet sonarscanner begin /k:"${{ inputs.sonar-project-key }}" \
           /o:"${{ inputs.sonar-organization }}" \
           /d:sonar.host.url="${{ inputs.sonar-url }}" \
-          /d:sonar.login="${{ inputs.sonar-login }}" \
+          /d:sonar.token="${{ inputs.sonar-token }}" \
           /d:sonar.cs.opencover.reportsPaths="${{ inputs.dotnet-test-project }}/coverage.opencover.xml" \
           /d:sonar.exclusions="${SONAR_EXCLUSIONS:-''}" \
           /d:sonar.coverage.exclusions="$CODE_COVERAGE_EXCLUSIONS" \
@@ -94,7 +94,7 @@ runs:
         dotnet sonarscanner begin /k:"${{ inputs.sonar-project-key }}" \
           /o:"${{ inputs.sonar-organization }}" \
           /d:sonar.host.url="${{ inputs.sonar-url }}" \
-          /d:sonar.login="${{ inputs.sonar-login }}" \
+          /d:sonar.token="${{ inputs.sonar-token }}" \
           /d:sonar.cs.opencover.reportsPaths="${{ inputs.dotnet-test-project }}/coverage.opencover.xml" \
           /d:sonar.exclusions="${SONAR_EXCLUSIONS:-''}" \
           /d:sonar.coverage.exclusions="${SONAR_CODE_COVERAGE_EXCLUSIONS:-''}" \
@@ -151,5 +151,5 @@ runs:
       shell: bash
 
     - name: Complete Analysis
-      run: dotnet sonarscanner end /d:sonar.login=${{ inputs.sonar-login }}
+      run: dotnet sonarscanner end /d:sonar.token=${{ inputs.sonar-token }}
       shell: bash


### PR DESCRIPTION
This pull request updates the authentication method for the SonarCloud Scanner GitHub Action to use the `sonar.token` parameter instead of `sonar.login`, reflecting SonarCloud's current deprecation of login. The input name is also updated for clarity. These changes improve security and compatibility with SonarCloud.

Authentication updates:
* Renamed the action input from `sonar-login` to `sonar-token` in `action.yaml` for clarity and alignment with SonarCloud terminology.
* Updated all SonarScanner command invocations in `action.yaml` to use `/d:sonar.token` instead of `/d:sonar.login`, ensuring proper authentication with SonarCloud.