### PR TITLE
chore: add JetBrains ignores and fix README version-tag commands

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,9 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+**/*.xml

--- a/.idea/dotnet-sonar-scanner.iml
+++ b/.idea/dotnet-sonar-scanner.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/README.md
+++ b/README.md
@@ -152,15 +152,15 @@ For example, if we introduce a version `2.2`, we should end up with a set of tag
 #### Create New Major Version Tag
 
 ```bash
-git tag -a v1
 git tag -a v1.0
+git tag -a v1 v1.0
 git push origin --tags
 ```
 
 #### Create New Minor Version Tag
 
 ```bash
-git tag -af v1
 git tag -a v1.1
+git tag -f v1 v1.1
 git push origin -f --tags
 ```


### PR DESCRIPTION
## Summary

Repository housekeeping and a documentation fix for the version-tagging workflow.

## Changes

- **chore: add JetBrains `.idea` ignores** — adds `.idea/.gitignore` and `.idea/dotnet-sonar-scanner.iml` so the IntelliJ/Rider project metadata is tracked/ignored appropriately, plus a root `.gitignore`.
- **docs: fix major/minor version tag commands in README** — corrects the tag commands so the floating major tag (`v1`) is created/moved to point at the specific version tag:
  - Major: `git tag -a v1 v1.0` after creating `v1.0`
  - Minor: `git tag -f v1 v1.1` to move `v1` onto the new minor release

## Notes

No functional changes to the action itself — docs and editor config only.
